### PR TITLE
Simplify specifying of a JSON-RPC ID parameter

### DIFF
--- a/src/Anemonis.JsonRpc.Benchmarks/TestSuites/JsonRpcSerializerSerializeBenchmarks.cs
+++ b/src/Anemonis.JsonRpc.Benchmarks/TestSuites/JsonRpcSerializerSerializeBenchmarks.cs
@@ -54,7 +54,7 @@ namespace Anemonis.JsonRpc.Benchmarks.TestSuites
 
         private static JsonRpcRequest CreateRequestParamsNone()
         {
-            return new JsonRpcRequest("m", 0L);
+            return new JsonRpcRequest(0L, "m");
         }
 
         private static JsonRpcRequest CreateRequestParamsByName()
@@ -64,7 +64,7 @@ namespace Anemonis.JsonRpc.Benchmarks.TestSuites
                 ["p"] = 0L
             };
 
-            return new JsonRpcRequest("m", 0L, parameters);
+            return new JsonRpcRequest(0L, "m", parameters);
         }
 
         private static JsonRpcRequest CreateRequestParamsByPosition()
@@ -74,7 +74,7 @@ namespace Anemonis.JsonRpc.Benchmarks.TestSuites
                 0L
             };
 
-            return new JsonRpcRequest("m", 0L, parameters);
+            return new JsonRpcRequest(0L, "m", parameters);
         }
 
         private static JsonRpcResponse CreateResponseSuccess()
@@ -84,12 +84,12 @@ namespace Anemonis.JsonRpc.Benchmarks.TestSuites
 
         private static JsonRpcResponse CreateResponseError()
         {
-            return new JsonRpcResponse(new JsonRpcError(0L, "m"), 0L);
+            return new JsonRpcResponse(0L, new JsonRpcError(0L, "m"));
         }
 
         private static JsonRpcResponse CreateResponseErrorWithData()
         {
-            return new JsonRpcResponse(new JsonRpcError(0L, "m", 0L), 0L);
+            return new JsonRpcResponse(0L, new JsonRpcError(0L, "m", 0L));
         }
 
         [Benchmark(Description = "SerializeRequest-PARAMS=U")]

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcRequestTests.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcRequestTests.cs
@@ -10,7 +10,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void IsNotificationIsTrueWhenIdIsNone()
         {
-            var message = new JsonRpcRequest("m");
+            var message = new JsonRpcRequest(default, "m");
 
             Assert.AreEqual(default, message.Id);
             Assert.IsTrue(message.IsNotification);
@@ -19,7 +19,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void IsNotificationIsFalseWhenIdIsNumber()
         {
-            var message = new JsonRpcRequest("m", 1L);
+            var message = new JsonRpcRequest(1L, "m");
 
             Assert.AreEqual(1L, message.Id);
             Assert.IsFalse(message.IsNotification);
@@ -28,7 +28,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void IsNotificationIsFalseWhenIdIsString()
         {
-            var message = new JsonRpcRequest("m", "1");
+            var message = new JsonRpcRequest("1", "m");
 
             Assert.AreEqual("1", message.Id);
             Assert.IsFalse(message.IsNotification);
@@ -37,7 +37,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void ParametersTypeIsNoneWhenIdIsNone()
         {
-            var message = new JsonRpcRequest("m");
+            var message = new JsonRpcRequest(default, "m");
 
             Assert.AreEqual(JsonRpcParametersType.None, message.ParametersType);
         }
@@ -46,7 +46,7 @@ namespace Anemonis.JsonRpc.UnitTests
         public void ParametersTypeIsByPositionWhenIdIsNone()
         {
             var parameters = new object[] { 1L };
-            var message = new JsonRpcRequest("m", parameters);
+            var message = new JsonRpcRequest(default, "m", parameters);
 
             Assert.AreEqual(JsonRpcParametersType.ByPosition, message.ParametersType);
         }
@@ -55,7 +55,7 @@ namespace Anemonis.JsonRpc.UnitTests
         public void ParametersTypeIsByNameWhenIdIsNone()
         {
             var parameters = new Dictionary<string, object> { ["p"] = 1L };
-            var message = new JsonRpcRequest("m", parameters);
+            var message = new JsonRpcRequest(default, "m", parameters);
 
             Assert.AreEqual(JsonRpcParametersType.ByName, message.ParametersType);
         }
@@ -63,7 +63,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void IsSystemIsFalse()
         {
-            var message = new JsonRpcRequest("m");
+            var message = new JsonRpcRequest(default, "m");
 
             Assert.IsFalse(message.IsSystem);
         }
@@ -71,7 +71,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void IsSystemIsTrue()
         {
-            var message = new JsonRpcRequest("rpc.m");
+            var message = new JsonRpcRequest(default, "rpc.m");
 
             Assert.IsTrue(message.IsSystem);
         }
@@ -80,13 +80,13 @@ namespace Anemonis.JsonRpc.UnitTests
         public void MethodIsNull()
         {
             Assert.ThrowsException<ArgumentNullException>(() =>
-                new JsonRpcRequest((string)null));
+                new JsonRpcRequest(default, null));
         }
 
         [TestMethod]
         public void MethodIsEmptyString()
         {
-            var message = new JsonRpcRequest("");
+            var message = new JsonRpcRequest(default, "");
 
             Assert.AreEqual("", message.Method);
         }

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcResponseTests.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcResponseTests.cs
@@ -9,7 +9,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsFalse()
         {
-            var message = new JsonRpcResponse(new JsonRpcError(2L, "m"), 1L);
+            var message = new JsonRpcResponse(1L, new JsonRpcError(2L, "m"));
 
             Assert.IsFalse(message.Success);
             Assert.IsNotNull(message.Error);
@@ -19,7 +19,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsTrueWhenResultIsNumber()
         {
-            var message = new JsonRpcResponse(0L, 1L);
+            var message = new JsonRpcResponse(1L, 0L);
 
             Assert.IsTrue(message.Success);
             Assert.IsNull(message.Error);
@@ -28,7 +28,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsTrueWhenResultIsString()
         {
-            var message = new JsonRpcResponse("0", 1L);
+            var message = new JsonRpcResponse(1L, "0");
 
             Assert.IsTrue(message.Success);
             Assert.IsNull(message.Error);
@@ -37,7 +37,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsTrueWhenResultIsBoolean()
         {
-            var message = new JsonRpcResponse(true, 1L);
+            var message = new JsonRpcResponse(1L, true);
 
             Assert.IsTrue(message.Success);
             Assert.IsNull(message.Error);
@@ -46,7 +46,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsTrueWhenResultIsObject()
         {
-            var message = new JsonRpcResponse(new object(), 1L);
+            var message = new JsonRpcResponse(1L, new object());
 
             Assert.IsTrue(message.Success);
             Assert.IsNull(message.Error);
@@ -55,7 +55,7 @@ namespace Anemonis.JsonRpc.UnitTests
         [TestMethod]
         public void SuccessIsTrueWhenResultIsNull()
         {
-            var message = new JsonRpcResponse(default(object), 1L);
+            var message = new JsonRpcResponse(1L, default(object));
 
             Assert.IsTrue(message.Success);
             Assert.IsNull(message.Error);
@@ -65,14 +65,14 @@ namespace Anemonis.JsonRpc.UnitTests
         public void SuccessIsTrueWhenIdIsNone()
         {
             Assert.ThrowsException<ArgumentException>(() =>
-                new JsonRpcResponse(1L, default(JsonRpcId)));
+                new JsonRpcResponse(default, 1L));
         }
 
         [TestMethod]
         public void SuccessIsFalseWhenErrorIsNull()
         {
             Assert.ThrowsException<ArgumentNullException>(() =>
-                new JsonRpcResponse(default(JsonRpcError), 1L));
+                new JsonRpcResponse(1L, default(JsonRpcError)));
         }
     }
 }

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V1.Specification.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V1.Specification.cs
@@ -42,7 +42,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_01.0_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcRequest("echo", 1L, new object[] { "Hello JSON-RPC" });
+            var jsonRpcMessage = new JsonRpcRequest(1L, "echo", new object[] { "Hello JSON-RPC" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -78,7 +78,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_01.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcResponse("Hello JSON-RPC", 1L);
+            var jsonRpcMessage = new JsonRpcResponse(1L, "Hello JSON-RPC");
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -119,7 +119,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.0_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcRequest("postMessage", 99L, new object[] { "Hello all!" });
+            var jsonRpcMessage = new JsonRpcRequest(99L, "postMessage", new object[] { "Hello all!" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -156,7 +156,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcResponse(1L, 99L);
+            var jsonRpcMessage = new JsonRpcResponse(99L, 1L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -193,7 +193,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.1_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcRequest("handleMessage", new object[] { "user1", "we were just talking" });
+            var jsonRpcMessage = new JsonRpcRequest(default, "handleMessage", new object[] { "user1", "we were just talking" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -242,7 +242,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.2_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcRequest("handleMessage", new object[] { "user3", "sorry, gotta go now, ttyl" });
+            var jsonRpcMessage = new JsonRpcRequest(default, "handleMessage", new object[] { "user3", "sorry, gotta go now, ttyl" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -291,7 +291,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.3_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcRequest("postMessage", 101L, new object[] { "I have a question:" });
+            var jsonRpcMessage = new JsonRpcRequest(101L, "postMessage", new object[] { "I have a question:" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -340,7 +340,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.4_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcRequest("userLeft", new object[] { "user3" });
+            var jsonRpcMessage = new JsonRpcRequest(default, "userLeft", new object[] { "user3" });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -400,7 +400,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_spec_02.5_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
-            var jsonRpcMessage = new JsonRpcResponse(1L, 101L);
+            var jsonRpcMessage = new JsonRpcResponse(101L, 1L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V1.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V1.cs
@@ -43,7 +43,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_btc_01_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcRequest("getblockhash", "foo", new object[] { 0L });
+            var jsonRpcMessage = new JsonRpcRequest("foo", "getblockhash", new object[] { 0L });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -80,7 +80,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_btc_01_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcResponse("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f", "foo");
+            var jsonRpcMessage = new JsonRpcResponse("foo", "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -122,7 +122,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_btc_02_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcRequest("getblockhash", "foo", new object[] { -1L });
+            var jsonRpcMessage = new JsonRpcRequest("foo", "getblockhash", new object[] { -1L });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -163,7 +163,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v1_btc_02_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
 
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(-8L, "Block height out of range"), "foo");
+            var jsonRpcMessage = new JsonRpcResponse("foo", new JsonRpcError(-8L, "Block height out of range"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -178,7 +178,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonRpcSerializer = new JsonRpcSerializer(compatibilityLevel: JsonRpcCompatibilityLevel.Level1);
             var parameters = new Dictionary<string, object> { ["p"] = 1L };
-            var message = new JsonRpcRequest("m", parameters);
+            var message = new JsonRpcRequest(default, "m", parameters);
 
             var exception = Assert.ThrowsException<JsonRpcSerializationException>(() =>
                 jsonRpcSerializer.SerializeRequest(message));

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V2.Specification.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V2.Specification.cs
@@ -42,7 +42,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_01.0_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("subtract", 1L, new object[] { 42L, 23L });
+            var jsonRpcMessage = new JsonRpcRequest(1L, "subtract", new object[] { 42L, 23L });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -78,7 +78,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_01.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(19L, 1L);
+            var jsonRpcMessage = new JsonRpcResponse(1L, 19L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -114,7 +114,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_01.1_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("subtract", 2L, new object[] { 23L, 42L });
+            var jsonRpcMessage = new JsonRpcRequest(2L, "subtract", new object[] { 23L, 42L });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -150,7 +150,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_01.1_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(-19L, 2L);
+            var jsonRpcMessage = new JsonRpcResponse(2L, -19L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -204,7 +204,7 @@ namespace Anemonis.JsonRpc.UnitTests
                 ["minuend"] = 42L
             };
 
-            var jsonRpcMessage = new JsonRpcRequest("subtract", 3L, jsonRpcSubtractParameters);
+            var jsonRpcMessage = new JsonRpcRequest(3L, "subtract", jsonRpcSubtractParameters);
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -240,7 +240,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_02.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(19L, 3L);
+            var jsonRpcMessage = new JsonRpcResponse(3L, 19L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -290,7 +290,7 @@ namespace Anemonis.JsonRpc.UnitTests
                 ["minuend"] = 42L
             };
 
-            var jsonRpcMessage = new JsonRpcRequest("subtract", 4L, jsonRpcSubtractParameters);
+            var jsonRpcMessage = new JsonRpcRequest(4L, "subtract", jsonRpcSubtractParameters);
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -326,7 +326,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_02.1_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(19L, 4L);
+            var jsonRpcMessage = new JsonRpcResponse(4L, 19L);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -367,7 +367,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_03.0_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("update", new object[] { 1L, 2L, 3L, 4L, 5L });
+            var jsonRpcMessage = new JsonRpcRequest(default, "update", new object[] { 1L, 2L, 3L, 4L, 5L });
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -402,7 +402,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_03.1_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("foobar");
+            var jsonRpcMessage = new JsonRpcRequest(default, "foobar");
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -441,7 +441,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_04.0_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("foobar", "1");
+            var jsonRpcMessage = new JsonRpcRequest("1", "foobar");
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -479,7 +479,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_04.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMethod, "Method not found"), "1");
+            var jsonRpcMessage = new JsonRpcResponse("1", new JsonRpcError(JsonRpcErrorCode.InvalidMethod, "Method not found"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -535,7 +535,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_05.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidFormat, "Parse error"), default);
+            var jsonRpcMessage = new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidFormat, "Parse error"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -600,7 +600,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_06.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default);
+            var jsonRpcMessage = new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -656,7 +656,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_07.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidFormat, "Parse error"), default);
+            var jsonRpcMessage = new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidFormat, "Parse error"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -712,7 +712,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_08.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default);
+            var jsonRpcMessage = new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"));
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -776,7 +776,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_spec_09.0_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default);
+            var jsonRpcMessage = new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"));
             var jsonResult = jsonRpcSerializer.SerializeResponses(new[] { jsonRpcMessage });
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -844,9 +844,9 @@ namespace Anemonis.JsonRpc.UnitTests
 
             var jsonRpcMessages = new[]
             {
-                new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default),
-                new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default),
-                new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default)
+                new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request")),
+                new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request")),
+                new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"))
             };
 
             var jsonResult = jsonRpcSerializer.SerializeResponses(jsonRpcMessages);
@@ -1020,11 +1020,11 @@ namespace Anemonis.JsonRpc.UnitTests
 
             var jsonRpcMessages = new[]
             {
-                new JsonRpcResponse(7L, "1"),
-                new JsonRpcResponse(19L, "2"),
-                new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request"), default),
-                new JsonRpcResponse(new JsonRpcError(JsonRpcErrorCode.InvalidMethod, "Method not found"), "5"),
-                new JsonRpcResponse(new object[] { "hello", 5L }, "9")
+                new JsonRpcResponse("1", 7L),
+                new JsonRpcResponse("2", 19L),
+                new JsonRpcResponse(default, new JsonRpcError(JsonRpcErrorCode.InvalidMessage, "Invalid Request")),
+                new JsonRpcResponse("5", new JsonRpcError(JsonRpcErrorCode.InvalidMethod, "Method not found")),
+                new JsonRpcResponse("9", new object[] { "hello", 5L })
             };
 
             var jsonResult = jsonRpcSerializer.SerializeResponses(jsonRpcMessages);
@@ -1082,8 +1082,8 @@ namespace Anemonis.JsonRpc.UnitTests
 
             var jsonRpcMessages = new[]
             {
-                new JsonRpcRequest("notify_sum", new object[] { 1L, 2L, 4L }),
-                new JsonRpcRequest("notify_hello", new object[] { 7L })
+                new JsonRpcRequest(default, "notify_sum", new object[] { 1L, 2L, 4L }),
+                new JsonRpcRequest(default, "notify_hello", new object[] { 7L })
             };
 
             var jsonResult = jsonRpcSerializer.SerializeRequests(jsonRpcMessages);

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V2.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.V2.cs
@@ -176,7 +176,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_error_has_data_false.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcError = new JsonRpcError(0L, "m");
-            var jsonRpcMessage = new JsonRpcResponse(jsonRpcError, 1L);
+            var jsonRpcMessage = new JsonRpcResponse(1L, jsonRpcError);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -216,7 +216,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_error_has_data_true.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcError = new JsonRpcError(0L, "m", 0L);
-            var jsonRpcMessage = new JsonRpcResponse(jsonRpcError, 1L);
+            var jsonRpcMessage = new JsonRpcResponse(1L, jsonRpcError);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -256,7 +256,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_error_has_data_true_null.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcError = new JsonRpcError(0L, "m", null);
-            var jsonRpcMessage = new JsonRpcResponse(jsonRpcError, 1L);
+            var jsonRpcMessage = new JsonRpcResponse(1L, jsonRpcError);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -312,7 +312,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_id_float_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("m", 1D);
+            var jsonRpcMessage = new JsonRpcRequest(1D, "m");
             var jsonResult = jsonRpcSerializer.SerializeRequest(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);
@@ -347,7 +347,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_id_float_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcResponse(string.Empty, 1D);
+            var jsonRpcMessage = new JsonRpcResponse(1D, string.Empty);
             var jsonResult = jsonRpcSerializer.SerializeResponse(jsonRpcMessage);
 
             CompareJsonStrings(jsonSample, jsonResult);

--- a/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.cs
+++ b/src/Anemonis.JsonRpc.UnitTests/JsonRpcSerializerTests.cs
@@ -85,7 +85,7 @@ namespace Anemonis.JsonRpc.UnitTests
         public void CoreSerializeRequestToStreamWhenStreamIsNull()
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("m", 0L);
+            var jsonRpcMessage = new JsonRpcRequest(0L, "m");
 
             Assert.ThrowsException<ArgumentNullException>(() =>
                 jsonRpcSerializer.SerializeRequest(jsonRpcMessage, null));
@@ -96,7 +96,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("m", 0L);
+            var jsonRpcMessage = new JsonRpcRequest(0L, "m");
 
             using (var jsonStream = new MemoryStream())
             {
@@ -124,7 +124,7 @@ namespace Anemonis.JsonRpc.UnitTests
         public async Task CoreSerializeRequestAsyncToStreamWhenStreamIsNull()
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("m", 0L);
+            var jsonRpcMessage = new JsonRpcRequest(0L, "m");
 
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(() =>
                 jsonRpcSerializer.SerializeRequestAsync(jsonRpcMessage, null).AsTask());
@@ -135,7 +135,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage = new JsonRpcRequest("m", 0L);
+            var jsonRpcMessage = new JsonRpcRequest(0L, "m");
 
             using (var jsonStream = new MemoryStream())
             {
@@ -163,8 +163,8 @@ namespace Anemonis.JsonRpc.UnitTests
         public void CoreSerializeRequestsToStreamWhenStreamIsNull()
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage1 = new JsonRpcRequest("m", 0L);
-            var jsonRpcMessage2 = new JsonRpcRequest("m", 1L);
+            var jsonRpcMessage1 = new JsonRpcRequest(0L, "m");
+            var jsonRpcMessage2 = new JsonRpcRequest(1L, "m");
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             Assert.ThrowsException<ArgumentNullException>(() =>
@@ -176,8 +176,8 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_batch_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage1 = new JsonRpcRequest("m", 0L);
-            var jsonRpcMessage2 = new JsonRpcRequest("m", 1L);
+            var jsonRpcMessage1 = new JsonRpcRequest(0L, "m");
+            var jsonRpcMessage2 = new JsonRpcRequest(1L, "m");
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             using (var jsonStream = new MemoryStream())
@@ -206,8 +206,8 @@ namespace Anemonis.JsonRpc.UnitTests
         public async Task CoreSerializeRequestsAsyncToStreamWhenStreamIsNull()
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage1 = new JsonRpcRequest("m", 0L);
-            var jsonRpcMessage2 = new JsonRpcRequest("m", 1L);
+            var jsonRpcMessage1 = new JsonRpcRequest(0L, "m");
+            var jsonRpcMessage2 = new JsonRpcRequest(1L, "m");
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(() =>
@@ -219,8 +219,8 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_batch_req.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
-            var jsonRpcMessage1 = new JsonRpcRequest("m", 0L);
-            var jsonRpcMessage2 = new JsonRpcRequest("m", 1L);
+            var jsonRpcMessage1 = new JsonRpcRequest(0L, "m");
+            var jsonRpcMessage2 = new JsonRpcRequest(1L, "m");
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             using (var jsonStream = new MemoryStream())
@@ -368,7 +368,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcMessage1 = new JsonRpcResponse(0L, 0L);
-            var jsonRpcMessage2 = new JsonRpcResponse(0L, 1L);
+            var jsonRpcMessage2 = new JsonRpcResponse(1L, 0L);
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             Assert.ThrowsException<ArgumentNullException>(() =>
@@ -381,7 +381,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_batch_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcMessage1 = new JsonRpcResponse(0L, 0L);
-            var jsonRpcMessage2 = new JsonRpcResponse(0L, 1L);
+            var jsonRpcMessage2 = new JsonRpcResponse(1L, 0L);
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             using (var jsonStream = new MemoryStream())
@@ -411,7 +411,7 @@ namespace Anemonis.JsonRpc.UnitTests
         {
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcMessage1 = new JsonRpcResponse(0L, 0L);
-            var jsonRpcMessage2 = new JsonRpcResponse(0L, 1L);
+            var jsonRpcMessage2 = new JsonRpcResponse(1L, 0L);
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(() =>
@@ -424,7 +424,7 @@ namespace Anemonis.JsonRpc.UnitTests
             var jsonSample = EmbeddedResourceManager.GetString("Assets.v2_core_batch_res.json");
             var jsonRpcSerializer = new JsonRpcSerializer();
             var jsonRpcMessage1 = new JsonRpcResponse(0L, 0L);
-            var jsonRpcMessage2 = new JsonRpcResponse(0L, 1L);
+            var jsonRpcMessage2 = new JsonRpcResponse(1L, 0L);
             var jsonRpcMessages = new[] { jsonRpcMessage1, jsonRpcMessage2 };
 
             using (var jsonStream = new MemoryStream())

--- a/src/Anemonis.JsonRpc/JsonRpcRequest.cs
+++ b/src/Anemonis.JsonRpc/JsonRpcRequest.cs
@@ -14,55 +14,10 @@ namespace Anemonis.JsonRpc
         private readonly IReadOnlyList<object> _parametersByPosition;
 
         /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="method" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method)
-        {
-            if (method == null)
-            {
-                throw new ArgumentNullException(nameof(method));
-            }
-
-            _method = method;
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
-        /// <param name="parameters">The parameters to be used during the invocation of the JSON-RPC method, provided by position.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="method" /> or <paramref name="parameters" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method, IReadOnlyList<object> parameters)
-            : this(method)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
-            _parametersType = JsonRpcParametersType.ByPosition;
-            _parametersByPosition = parameters;
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
-        /// <param name="parameters">The parameters to be used during the invocation of the JSON-RPC method, provided by name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="method" /> or <paramref name="parameters" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method, IReadOnlyDictionary<string, object> parameters)
-            : this(method)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
-            _parametersType = JsonRpcParametersType.ByName;
-            _parametersByName = parameters;
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <param name="id">The identifier established by the client.</param>
+        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <exception cref="ArgumentNullException"><paramref name="method" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method, in JsonRpcId id)
+        public JsonRpcRequest(in JsonRpcId id, string method)
             : base(id)
         {
             if (method == null)
@@ -74,12 +29,12 @@ namespace Anemonis.JsonRpc
         }
 
         /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <param name="id">The identifier established by the client.</param>
+        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <param name="parameters">The parameters to be used during the invocation of the JSON-RPC method, provided by position.</param>
         /// <exception cref="ArgumentNullException"><paramref name="method" /> or <paramref name="parameters" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method, in JsonRpcId id, IReadOnlyList<object> parameters)
-            : this(method, id)
+        public JsonRpcRequest(in JsonRpcId id, string method, IReadOnlyList<object> parameters)
+            : this(id, method)
         {
             if (parameters == null)
             {
@@ -91,12 +46,12 @@ namespace Anemonis.JsonRpc
         }
 
         /// <summary>Initializes a new instance of the <see cref="JsonRpcRequest" /> class.</summary>
-        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <param name="id">The identifier established by the client.</param>
+        /// <param name="method">The string containing the name of the JSON-RPC method to be invoked.</param>
         /// <param name="parameters">The parameters to be used during the invocation of the JSON-RPC method, provided by name.</param>
         /// <exception cref="ArgumentNullException"><paramref name="method" /> or <paramref name="parameters" /> is <see langword="null" />.</exception>
-        public JsonRpcRequest(string method, in JsonRpcId id, IReadOnlyDictionary<string, object> parameters)
-            : this(method, id)
+        public JsonRpcRequest(in JsonRpcId id, string method, IReadOnlyDictionary<string, object> parameters)
+            : this(id, method)
         {
             if (parameters == null)
             {

--- a/src/Anemonis.JsonRpc/JsonRpcResponse.cs
+++ b/src/Anemonis.JsonRpc/JsonRpcResponse.cs
@@ -12,10 +12,10 @@ namespace Anemonis.JsonRpc
         private readonly JsonRpcError _error;
 
         /// <summary>Initializes a new instance of the <see cref="JsonRpcResponse" /> class.</summary>
-        /// <param name="result">The produced result for successful request.</param>
         /// <param name="id">The identifier, which must be the same as the identifier in the JSON-RPC request.</param>
+        /// <param name="result">The produced result for successful request.</param>
         /// <exception cref="ArgumentException"><paramref name="id" /> has undefined value.</exception>
-        public JsonRpcResponse(object result, in JsonRpcId id)
+        public JsonRpcResponse(in JsonRpcId id, object result)
             : base(id)
         {
             if (id.Type == JsonRpcIdType.None)
@@ -27,10 +27,10 @@ namespace Anemonis.JsonRpc
         }
 
         /// <summary>Initializes a new instance of the <see cref="JsonRpcResponse" /> class.</summary>
-        /// <param name="error">The produced JSON-RPC error for unsuccessful request.</param>
         /// <param name="id">The identifier, which must be the same as the identifier in the JSON-RPC request.</param>
+        /// <param name="error">The produced JSON-RPC error for unsuccessful request.</param>
         /// <exception cref="ArgumentNullException"><paramref name="error" /> is <see langword="null" />.</exception>
-        public JsonRpcResponse(JsonRpcError error, in JsonRpcId id)
+        public JsonRpcResponse(in JsonRpcId id, JsonRpcError error)
             : base(id)
         {
             if (error == null)

--- a/src/Anemonis.JsonRpc/JsonRpcSerializer.Engine.cs
+++ b/src/Anemonis.JsonRpc/JsonRpcSerializer.Engine.cs
@@ -298,7 +298,7 @@ namespace Anemonis.JsonRpc
                                 throw new JsonSerializationException(Strings.GetString("core.deserialize.json_issue"), e);
                             }
 
-                            request = new JsonRpcRequest(requestMethod, requestId, requestParameters);
+                            request = new JsonRpcRequest(requestId, requestMethod, requestParameters);
                         }
                         break;
                     case JsonRpcParametersType.ByName:
@@ -346,12 +346,12 @@ namespace Anemonis.JsonRpc
                                 throw new JsonSerializationException(Strings.GetString("core.deserialize.json_issue"), e);
                             }
 
-                            request = new JsonRpcRequest(requestMethod, requestId, requestParameters);
+                            request = new JsonRpcRequest(requestId, requestMethod, requestParameters);
                         }
                         break;
                     default:
                         {
-                            request = new JsonRpcRequest(requestMethod, requestId);
+                            request = new JsonRpcRequest(requestId, requestMethod);
                         }
                         break;
                 }
@@ -664,7 +664,7 @@ namespace Anemonis.JsonRpc
                         }
                     }
 
-                    response = new JsonRpcResponse(responseResult, responseId);
+                    response = new JsonRpcResponse(responseId, responseResult);
                 }
                 else
                 {
@@ -762,7 +762,7 @@ namespace Anemonis.JsonRpc
                         }
                     }
 
-                    response = new JsonRpcResponse(responseError, responseId);
+                    response = new JsonRpcResponse(responseId, responseError);
                 }
 
                 return new JsonRpcMessageInfo<JsonRpcResponse>(response);


### PR DESCRIPTION
### Summary

Simplify and unify specifying of a JSON-RPC ID parameter in requests and responses.

### Changes

- Set ID as the first parameter for the request type constructors.
- Set ID as the first parameter for the response type constructors.
- Removed constructor overloads without ID from the request type.

### Outcome

- Simplified and unified specifying of a JSON-RPC ID parameter in requests and responses.