### PR TITLE
Remove dotnet.use.sonar step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,11 +38,6 @@ stages:
   - job: Release
     steps:
     - task: UseDotNet@2
-      displayName: 'dotnet.use.sonar'
-      inputs:
-        packageType: runtime
-        version: 2.x
-    - task: UseDotNet@2
       displayName: 'dotnet.use.sdk'
       inputs:
         useGlobalJson: true


### PR DESCRIPTION
Remove dotnet.use.sonar step that installs .NET Core SDK 2.0 for SonarCloud in Azure DevOps.

REF: https://github.com/SonarSource/sonar-scanner-msbuild/issues/797