### PR TITLE
Publish library for dotnet standard

### DIFF
--- a/src/Anemonis.JsonRpc/Anemonis.JsonRpc.csproj
+++ b/src/Anemonis.JsonRpc/Anemonis.JsonRpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackageProject>true</IsPackageProject>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />


### PR DESCRIPTION
### Summary

+ Publish the library for dotnet standard to use in other library projects. 

### Changes

+ Add TargetFramework: netstandard2.1

### Outcome

+ Nuget can be used in netstandard2.1 library project

### Additional Information

+ project successful build in Visual Studio
+ please check for other required modifications